### PR TITLE
fix: log installation error and continue

### DIFF
--- a/src/cron.ts
+++ b/src/cron.ts
@@ -2,5 +2,9 @@ import updateTraffic from './services/updateTraffic';
 import { app } from './utils/octokit';
 
 app.eachInstallation(({ installation }) => {
-  updateTraffic(installation.id);
+  try {
+    updateTraffic(installation.id);
+  } catch (error) {
+    console.error(`An unexpected error occurred for installation with id '${installation.id}'`, error);
+  }
 });


### PR DESCRIPTION
If an error occurs for a specific installation, the error would cause the entire cron job to stop.

By catching the error at a high level in the loop, we can be tolerant to unexpected errors. This means the loop can continue with the next installation. We can also log the error for further investigation.

This has one big downside: it may hide errors as the cron job workflow run just continues.

resolves #7 